### PR TITLE
Fix `GotRedemptionSignature` Handler Deposit State

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -268,7 +268,7 @@ export function handleRedemptionRequestedEvent(
 export function handleGotRedemptionSignatureEvent(
   event: GotRedemptionSignature
 ): void {
-  setDepositState(event.params._depositContractAddress, "AWAITING_WITHDRAWAL_SIGNATURE");
+  setDepositState(event.params._depositContractAddress, "AWAITING_WITHDRAWAL_PROOF");
 
   let logEvent = new GotRedemptionSignatureEvent(getIDFromEvent(event))
   logEvent.deposit = getDepositIdFromAddress(event.params._depositContractAddress);


### PR DESCRIPTION
The deposit state should be set to `AWAITING_WITHDRAWAL_PROOF ` once a `GotRedemptionSignature` event is received. 

[Source](https://github.com/keep-network/tbtc/blob/v1.1.0/solidity/contracts/deposit/DepositRedemption.sol#L203-L207)