### PR TITLE
Add support for cancelStake()

### DIFF
--- a/src/mappingTokenStaking.ts
+++ b/src/mappingTokenStaking.ts
@@ -1,5 +1,6 @@
 import {
   AuthorizeOperatorContractCall,
+  CancelStakeCall,
   ExpiredLockReleased,
   LockReleased,
   OperatorStaked,
@@ -130,6 +131,17 @@ export function handleRecoveredStake(event: RecoveredStake): void{
   // tokenStaking.save()
 
 
+}
+
+/**
+ * Call: cancelStake().
+ *
+ * Called when a delegation is cancelled a few hours after it was started
+ */
+export function handleCancelledStake(call: CancelStakeCall): void{
+  let operator = getOrCreateOperator(call.inputs._operator);
+  operator.stakedAmount = BIGDECIMAL_ZERO;
+  operator.save();
 }
 
 /**

--- a/subgraph.ropsten.yaml
+++ b/subgraph.ropsten.yaml
@@ -230,6 +230,8 @@ dataSources:
       callHandlers:
         - function: authorizeOperatorContract(address,address)
           handler: handleAuthorizeOperatorContract
+        - function: cancelStake(address)
+          handler: handleCancelledStake
       file: ./src/mappingTokenStaking.ts
 
   - kind: ethereum/contract

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -230,6 +230,8 @@ dataSources:
       callHandlers:
         - function: authorizeOperatorContract(address,address)
           handler: handleAuthorizeOperatorContract
+        - function: cancelStake(address)
+          handler: handleCancelledStake
       file: ./src/mappingTokenStaking.ts
 
   - kind: ethereum/contract

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -230,6 +230,8 @@ dataSources:
       callHandlers:
         - function: authorizeOperatorContract(address,address)
           handler: handleAuthorizeOperatorContract
+        - event: cancelStake(address)
+          handler: handleCancelledStake
       file: ./src/mappingTokenStaking.ts
 
   - kind: ethereum/contract

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -230,7 +230,7 @@ dataSources:
       callHandlers:
         - function: authorizeOperatorContract(address,address)
           handler: handleAuthorizeOperatorContract
-        - event: cancelStake(address)
+        - function: cancelStake(address)
           handler: handleCancelledStake
       file: ./src/mappingTokenStaking.ts
 
@@ -423,6 +423,9 @@ dataSources:
       eventHandlers:
         - event: RewardsClaimed(indexed bytes32,indexed uint256,indexed address,address,uint256)
           handler: handleRewardsClaimed
+        # Emitted once for each weekly interval. The actual mapping of amounts to operator addresses
+        # is in an off-chain JSON file, but we could read this to get total allocation numbers.
+        # RewardsAllocated(bytes32,uint256)
       file: ./src/mappingStakedrop.ts
   
 


### PR DESCRIPTION
When cancelStake() is called the stakedAmount of an operator is not correctly updated, this PR fixes this.